### PR TITLE
Updates Jenkins pipelines to set --no-git.requireCleanWorkingDir 

### DIFF
--- a/stable/appmod-liberty/Jenkinsfile
+++ b/stable/appmod-liberty/Jenkinsfile
@@ -220,6 +220,7 @@ spec:
                     release-it patch ${PRE_RELEASE} \
                       --ci \
                       --no-npm \
+                      --no-git.requireCleanWorkingDir \
                       --verbose \
                       -VV
 

--- a/stable/java-gradle/Jenkinsfile
+++ b/stable/java-gradle/Jenkinsfile
@@ -197,6 +197,7 @@ spec:
                     release-it patch ${PRE_RELEASE} \
                       --ci \
                       --no-npm \
+                      --no-git.requireCleanWorkingDir \
                       --verbose \
                       -VV
 

--- a/stable/java-maven/Jenkinsfile
+++ b/stable/java-maven/Jenkinsfile
@@ -220,6 +220,7 @@ spec:
                     release-it patch ${PRE_RELEASE} \
                       --ci \
                       --no-npm \
+                      --no-git.requireCleanWorkingDir \
                       --verbose \
                       -VV
 

--- a/stable/nodejs/Jenkinsfile
+++ b/stable/nodejs/Jenkinsfile
@@ -178,6 +178,7 @@ spec:
                     release-it patch ${PRE_RELEASE} \
                       --ci \
                       --no-npm \
+                      --no-git.requireCleanWorkingDir \
                       --verbose \
                       -VV
 


### PR DESCRIPTION
(ibm-garage-cloud/planning#208)

- Fixes build errors caused by release-it's check for a clean working dir before tagging the build