### PR TITLE
Reduces the length of the agent name to prevent Jenkins concat error

### DIFF
--- a/stable/appmod-liberty/Jenkinsfile
+++ b/stable/appmod-liberty/Jenkinsfile
@@ -13,8 +13,8 @@
 def buildAgentName(String jobNameWithNamespace, String buildNumber, String namespace) {
     def jobName = removeNamespaceFromJobName(jobNameWithNamespace, namespace);
 
-    if (jobName.length() > 55) {
-        jobName = jobName.substring(0, 55);
+    if (jobName.length() > 52) {
+        jobName = jobName.substring(0, 52);
     }
 
     return "a.${jobName}${buildNumber}".replace('_', '-').replace('/', '-').replace('-.', '.');

--- a/stable/java-gradle/Jenkinsfile
+++ b/stable/java-gradle/Jenkinsfile
@@ -13,8 +13,8 @@
 def buildAgentName(String jobNameWithNamespace, String buildNumber, String namespace) {
     def jobName = removeNamespaceFromJobName(jobNameWithNamespace, namespace);
 
-    if (jobName.length() > 55) {
-        jobName = jobName.substring(0, 55);
+    if (jobName.length() > 52) {
+        jobName = jobName.substring(0, 52);
     }
 
     return "a.${jobName}${buildNumber}".replace('_', '-').replace('/', '-').replace('-.', '.');

--- a/stable/java-maven/Jenkinsfile
+++ b/stable/java-maven/Jenkinsfile
@@ -13,8 +13,8 @@
 def buildAgentName(String jobNameWithNamespace, String buildNumber, String namespace) {
     def jobName = removeNamespaceFromJobName(jobNameWithNamespace, namespace);
 
-    if (jobName.length() > 55) {
-        jobName = jobName.substring(0, 55);
+    if (jobName.length() > 52) {
+        jobName = jobName.substring(0, 52);
     }
 
     return "a.${jobName}${buildNumber}".replace('_', '-').replace('/', '-').replace('-.', '.');

--- a/stable/nodejs/Jenkinsfile
+++ b/stable/nodejs/Jenkinsfile
@@ -14,8 +14,8 @@
 def buildAgentName(String jobNameWithNamespace, String buildNumber, String namespace) {
     def jobName = removeNamespaceFromJobName(jobNameWithNamespace, namespace);
 
-    if (jobName.length() > 55) {
-        jobName = jobName.substring(0, 55);
+    if (jobName.length() > 52) {
+        jobName = jobName.substring(0, 52);
     }
 
     return "a.${jobName}${buildNumber}".replace('_', '-').replace('/', '-').replace('-.', '.');


### PR DESCRIPTION
- Jenkins does not validate the pod names that it creates and can create names that won't start. This reduces the length of the pod name so that Jenkins won't create the problem

Addresses ibm-garage-cloud/planning#217