### PR TITLE
appmod-liberty: v1.1.5 - updates to helm chart

### DIFF
--- a/stable/appmod-liberty/chart/base/values.yaml
+++ b/stable/appmod-liberty/chart/base/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: replace
   tag: replace
   pullPolicy: IfNotPresent
-  port: 3000
+  port: 9080
 
 nameOverride: ""
 fullnameOverride: ""
@@ -35,6 +35,9 @@ ingress:
   path: "/"
 
 #  tlsSecretName: ""
+
+serviceAccount:
+  create: false
 
 vcsInfo:
   repoUrl: ""

--- a/stable/appmod-liberty/pipeline.yaml
+++ b/stable/appmod-liberty/pipeline.yaml
@@ -1,4 +1,4 @@
-version: 1.1.4
+version: 1.1.5
 name: appmod-liberty
 runtime: java
 build-tool: maven


### PR DESCRIPTION
- Changes port in values.yaml from 3000 to 9080 (liberty default port)
- Adds serviceAccount.create to values.yaml to avoid issues